### PR TITLE
Rework of the propulsion templates

### DIFF
--- a/src/rta/models/propulsion/component_base.py
+++ b/src/rta/models/propulsion/component_base.py
@@ -24,7 +24,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import ClassVar
 
-import pandas as pd
 from fastoad.model_base.flight_point import FlightPoint, _FieldDescriptor
 from fastoad.openmdao.variables import VariableList
 from openmdao.core.component import Component
@@ -180,39 +179,10 @@ class AbstractPropulsiveComponent(ABC):
                 f" Please ensure units consistency between input and output fields."
             )
 
-    def compute_performances(self, flight_point: FlightPoint | pd.DataFrame):
-        """
-        Compute the performance of the component for given flight point(s).
-
-        This method handles both single FlightPoint instances and lists of
-        FlightPoint instances. It delegates the actual computation to the
-        compute_single_point() method which must be implemented by subclasses.
-
-        Args:
-            flight_point: A FlightPoint or list of FlightPoint to compute
-                          performance for.
-
-
-        Raises:
-            NotImplementedError: If the subclass has not implemented
-                                 compute_single_point().
-        """
-
-        if isinstance(flight_point, pd.DataFrame):
-            # Default inefficient but functional way of handling dataframe.
-            # User should redefine the method if relying heavily on dataframe,
-            # which is not the default case
-            for idx in flight_point.index:
-                fp = FlightPoint.create(flight_point.iloc[idx])
-                self.compute_single_point(fp)
-                flight_point.iloc[[idx]] = pd.DataFrame([fp])
-        else:
-            self.compute_single_point(flight_point)
-
     @abstractmethod
-    def compute_single_point(self, flight_point: FlightPoint) -> FlightPoint:
+    def compute_single_point_backward(self, flight_point: FlightPoint) -> FlightPoint:
         """
-        Compute performance for a single flight point.
+        Compute performance for a single flight point when thrust is regulated.
 
         Subclasses must override this method with their specific calculations.
         This method receives a FlightPoint with input values populated and
@@ -228,7 +198,29 @@ class AbstractPropulsiveComponent(ABC):
             NotImplementedError: If the subclass has not implemented this method.
         """
         raise NotImplementedError(
-            f"Subclass {self.__class__.__name__} must implement compute_single_point()"
+            f"Subclass {self.__class__.__name__} must implement compute_single_point_backward()"
+        )
+
+    @abstractmethod
+    def compute_single_point_forward(self, flight_point: FlightPoint) -> FlightPoint:
+        """
+        Compute performance for a single flight point when thrust is manual.
+
+        Subclasses must override this method with their specific calculations.
+        This method receives a FlightPoint with input values populated and
+        must return the same FlightPoint with output values computed and filled in.
+
+        Args:
+            flight_point: A single FlightPoint instance with input values set.
+
+        Returns:
+            The FlightPoint with computed output values.
+
+        Raises:
+            NotImplementedError: If the subclass has not implemented this method.
+        """
+        raise NotImplementedError(
+            f"Subclass {self.__class__.__name__} must implement compute_single_point_forward()"
         )
 
     def update_input_parameters(self, inputs: DefaultVector):

--- a/src/rta/models/propulsion/tests/dummy_components/gearbox.py
+++ b/src/rta/models/propulsion/tests/dummy_components/gearbox.py
@@ -84,7 +84,7 @@ class GearboxComponent(AbstractPropulsiveComponent):
     # Dictionary of FlightPoint fields to be computed (field_name: unit)
     _output_fields: ClassVar[dict] = OUTPUT_FIELDS
 
-    def compute_single_point_backward(self, flight_point: FlightPoint):
+    def compute_single_point_backward(self, flight_point: FlightPoint) -> FlightPoint:
         """
         Compute input shaft power for a single flight point.
 
@@ -104,7 +104,9 @@ class GearboxComponent(AbstractPropulsiveComponent):
         # Compute output power
         flight_point.TPshaft_power = output_power / efficiency
 
-    def compute_single_point_forward(self, flight_point: FlightPoint):
+        return flight_point
+
+    def compute_single_point_forward(self, flight_point: FlightPoint) -> FlightPoint:
         """
         Compute output shaft power for a single flight point.
 
@@ -123,3 +125,5 @@ class GearboxComponent(AbstractPropulsiveComponent):
 
         # Compute output power
         flight_point.gearbox_shaft_power = input_power * efficiency
+
+        return flight_point

--- a/src/rta/models/propulsion/tests/dummy_components/gearbox.py
+++ b/src/rta/models/propulsion/tests/dummy_components/gearbox.py
@@ -84,7 +84,7 @@ class GearboxComponent(AbstractPropulsiveComponent):
     # Dictionary of FlightPoint fields to be computed (field_name: unit)
     _output_fields: ClassVar[dict] = OUTPUT_FIELDS
 
-    def compute_single_point(self, flight_point: FlightPoint):
+    def compute_single_point_backward(self, flight_point: FlightPoint):
         """
         Compute input shaft power for a single flight point.
 
@@ -103,3 +103,23 @@ class GearboxComponent(AbstractPropulsiveComponent):
 
         # Compute output power
         flight_point.TPshaft_power = output_power / efficiency
+
+    def compute_single_point_forward(self, flight_point: FlightPoint):
+        """
+        Compute output shaft power for a single flight point.
+
+        Output Power = Input Power * Efficiency
+
+        Args:
+            flight_point: FlightPoint with TPshaft_power and efficiency set.
+
+        Returns:
+            FlightPoint with gearbox_shaft_power computed.
+        """
+        input_power = flight_point.TPshaft_power
+        efficiency = scalarize(
+            self.input_parameters["data:propulsion:gearbox:efficiency"].get_val()
+        )
+
+        # Compute output power
+        flight_point.gearbox_shaft_power = input_power * efficiency

--- a/src/rta/models/propulsion/tests/dummy_components/propeller.py
+++ b/src/rta/models/propulsion/tests/dummy_components/propeller.py
@@ -86,7 +86,7 @@ class PropellerComponent(AbstractPropulsiveComponent):
     # Dictionary of FlightPoint fields to be computed (field_name: unit)
     _output_fields: ClassVar[dict] = OUTPUT_FIELDS
 
-    def compute_single_point(self, flight_point: FlightPoint) -> FlightPoint:
+    def compute_single_point_backward(self, flight_point: FlightPoint) -> FlightPoint:
         """
         Compute shaft power for a single flight point.
 
@@ -107,5 +107,25 @@ class PropellerComponent(AbstractPropulsiveComponent):
             flight_point.gearbox_shaft_power = float("inf")
         else:
             flight_point.gearbox_shaft_power = thrust * true_airspeed / efficiency
+
+        return flight_point
+
+    def compute_single_point_forward(self, flight_point: FlightPoint) -> FlightPoint:
+        """
+        Compute thrust for a single flight point.
+
+        Thrust = Power * Efficiency / Velocity
+
+        Args:
+            flight_point: FlightPoint with power, velocity, and efficiency set.
+
+        Returns:
+            FlightPoint with thrust computed.
+        """
+        power = flight_point.gearbox_shaft_power
+        true_airspeed = flight_point.true_airspeed
+        efficiency = self.input_parameters["data:propulsion:propeller:efficiency"].get_val()
+
+        flight_point.thrust = power * efficiency / true_airspeed
 
         return flight_point

--- a/src/rta/models/propulsion/tests/dummy_components/propulsion_system_module.py
+++ b/src/rta/models/propulsion/tests/dummy_components/propulsion_system_module.py
@@ -61,6 +61,7 @@ class PropulsionSystemModule(PropulsionSystem):
         self.propeller = propeller
         self.gearbox = gearbox
         self.PSFC = 0.250  # kg/kWh
+        self.TPshaft_power_max = 20  # MW
 
     def get_consumed_mass(self, flight_point: FlightPoint, time_step: float) -> float:
         """Definition is mandatory but it is not used in this exemple"""
@@ -68,41 +69,102 @@ class PropulsionSystemModule(PropulsionSystem):
 
     def compute_flight_points(self, flight_points: FlightPoint | pd.DataFrame):
         """
-        Compute propulsion performance for flight point(s).
+        Compute the performance of the propulsion system for given flight point(s).
 
-        This method orchestrates the computation chain:
-        1. Call propeller compute_performances to compute gearbox_shaft_power
-        2. Call gearbox compute_performances to compute TPshaft_power
-        3. Calculate fuel flow as PSFC * TPshaft_power
-        4. Calculate SFC as fuel_flow / thrust
+        This method handles both single FlightPoint instances and lists of
+        FlightPoint instances. It delegates the actual computation to the
+        compute_flight_point() method.
 
         Args:
-            flight_points: A FlightPoint instance or DataFrame of flight points.
+            flight_points: A FlightPoint or list of FlightPoint to compute
+                          performance for.
+        """
+
+        if isinstance(flight_points, pd.DataFrame):
+            # Default inefficient but functional way of handling dataframe.
+            # User should redefine the method if relying heavily on dataframe,
+            # which is not the default case
+            for idx in flight_points.index:
+                fp = FlightPoint.create(flight_points.iloc[idx])
+                self.compute_flight_point(fp)
+                flight_points.iloc[[idx]] = pd.DataFrame([fp])
+        else:
+            self.compute_flight_point(flight_points)
+
+    def compute_flight_point(self, flight_point: FlightPoint):
+        """
+        Compute propulsion performance for a single flight point.
+
+        This method orchestrates the computation chain.
+        In backward mode
+            1. Call propeller compute_single_point_backward to compute gearbox_shaft_power
+            2. Call gearbox compute_single_point_backward to compute TPshaft_power
+            3. Calculate fuel flow as PSFC * TPshaft_power
+            4. Calculate SFC as fuel_flow / thrust
+        In forward mode
+            1. Calculate the gas turbine power at throttle ratio
+            2. Calculate fuel flow as PSFC * TPshaft_power
+            3. Calculate SFC as fuel_flow / thrust
+            4. Call gearbox compute_single_point_forward to compute gearbox_shaft_power
+            5. Call propeller compute_single_point_forward to compute thrust
+
+        Args:
+            flight_point: A FlightPoint instance.
 
         Returns:
-            The same FlightPoint(s) with computed outputs filled in:
+            The same FlightPoint with computed outputs filled in:
                 - psfc: Specific fuel consumption [kg/W/s]
                 - thrust: Thrust [N] (from input flight point)
                 - sfc: Specific fuel consumption [kg/N/s]
         """
 
-        # Step 1: Call propeller compute_perfo first
-        # This computes gearbox_shaft_power from thrust and true_airspeed
-        self.propeller.compute_performances(flight_points)
+        if flight_point.thrust_is_regulated:
+            # Step 1: Call propeller compute_single_point_backward first
+            # This computes gearbox_shaft_power from thrust and true_airspeed
+            self.propeller.compute_single_point_backward(flight_point)
 
-        # Step 2: Call gearbox compute_perfo
-        # This computes TPshaft_power from gearbox_shaft_power
-        self.gearbox.compute_performances(flight_points)
+            # Step 2: Call gearbox compute_single_point_backward
+            # This computes TPshaft_power from gearbox_shaft_power
+            self.gearbox.compute_single_point_backward(flight_point)
 
-        # Step 3: Calculate the fuel flow as: fuel_flow = PSFC * TPshaft_power
-        psfc_in_kg_per_w_s = self.PSFC / (1000.0 * 3600.0)  # kg/W/s
+            # Step 3: Calculate the fuel flow as: fuel_flow = PSFC * TPshaft_power
+            psfc_in_kg_per_w_s = self.PSFC / (1000.0 * 3600.0)  # kg/W/s
 
-        # Fuel flow in kg/s
-        fuel_flow = psfc_in_kg_per_w_s * flight_points.TPshaft_power
+            # Fuel flow in kg/s
+            fuel_flow = psfc_in_kg_per_w_s * flight_point.TPshaft_power
 
-        # Step 4: Calculate SFC [kg/N/s]
-        sfc = fuel_flow / flight_points.thrust
+            # Step 4: Calculate SFC [kg/N/s]
+            sfc = fuel_flow / flight_point.thrust
 
-        # Store results in flight point
-        flight_points.psfc = psfc_in_kg_per_w_s  # kg/W/s
-        flight_points.sfc = sfc  # kg/N/s
+            # Store results in flight point
+            flight_point.psfc = psfc_in_kg_per_w_s  # kg/W/s
+            flight_point.sfc = sfc  # kg/N/s
+
+            # Step 5: Calculate the throttle ratio, stored in the thrust rate
+            flight_point.thrust_rate = flight_point.TPshaft_power / (self.TPshaft_power_max * 1e6)
+
+        else:
+            # Step 1: Get the power available on the gas turbine first.
+            # Thrust rate acts here as a throttle ratio.
+            flight_point.TPshaft_power = self.TPshaft_power_max * 1e6 * flight_point.thrust_rate
+
+            # Step 2: Calculate the fuel flow as: fuel_flow = PSFC * TPshaft_power
+            psfc_in_kg_per_w_s = self.PSFC / (1000.0 * 3600.0)  # kg/W/s
+
+            # Fuel flow in kg/s
+            fuel_flow = psfc_in_kg_per_w_s * flight_point.TPshaft_power
+
+            # Step 3: Call the gearbox compute_single_point_forward
+            # This computes gearbox_shaft_power from TPshaft_power
+            self.gearbox.compute_single_point_forward(flight_point)
+
+            # Step 4: Finally, call the propeller compute_single_point_forward
+            # This computes thrust from gearbox_shaft_power and velocity
+            self.propeller.compute_single_point_forward(flight_point)
+
+            # Step 5: Calculate SFC [kg/N/s]
+            sfc = fuel_flow / flight_point.thrust
+
+            # Store results in flight point
+            flight_point.psfc = psfc_in_kg_per_w_s  # kg/W/s
+            flight_point.sfc = sfc  # kg/N/s

--- a/src/rta/models/propulsion/tests/dummy_components/propulsion_system_omwrapper.py
+++ b/src/rta/models/propulsion/tests/dummy_components/propulsion_system_omwrapper.py
@@ -20,6 +20,7 @@ for integration with FAST-OAD's OpenMDAO-based workflow.
 
 import numpy as np
 import openmdao.api as om
+import pandas as pd
 from fastoad.model_base import FlightPoint
 from fastoad.model_base.propulsion import (
     FuelEngineSet,
@@ -121,6 +122,9 @@ class PropulsionSystemOMComponent(om.ExplicitComponent):
         self.add_input("data:propulsion:true_airspeed", np.nan, units="m/s", shape_by_conn=True)
         self.add_input("data:propulsion:thrust", np.nan, units="N", shape_by_conn=True)
         self.add_input(
+            "data:propulsion:thrust_is_regulated", np.nan, units="unitless", shape_by_conn=True
+        )
+        self.add_input(
             "data:propulsion:engine_count",
             val=np.nan,
         )
@@ -139,10 +143,19 @@ class PropulsionSystemOMComponent(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         engine_set = self.get_wrapper().get_model(inputs)
 
-        airspeed = inputs["data:propulsion:true_airspeed"]
-        thrust = inputs["data:propulsion:thrust"]
+        flight_points = []
+        for airspeed, thrust, thrust_is_regulated in zip(
+            inputs["data:propulsion:true_airspeed"],
+            inputs["data:propulsion:thrust"],
+            inputs["data:propulsion:thrust_is_regulated"],
+        ):
+            flight_points.append(
+                FlightPoint(
+                    true_airspeed=airspeed, thrust=thrust, thrust_is_regulated=thrust_is_regulated
+                )
+            )
 
-        flight_points = FlightPoint(true_airspeed=airspeed, thrust=thrust)
+        flight_points = pd.DataFrame(flight_points)
 
         engine_set.compute_flight_points(flight_points)
 

--- a/src/rta/models/propulsion/tests/test_component_base.py
+++ b/src/rta/models/propulsion/tests/test_component_base.py
@@ -1,13 +1,11 @@
 """
 Tests for the AbstractPropulsiveComponent base class.
 
-This module tests the functionality of the AbstractPropulsiveComponent
-including FlightPoint field expansion, compute_performances() method, and
-VariableList updates.
+This module tests the functionality of the AbstractPropulsiveComponent including FlightPoint
+field expansion, compute_single_point_forward() and compute_single_point_backward() methods,
+and VariableList updates.
 """
 
-import numpy as np
-import pandas as pd
 import pytest
 from fastoad.model_base.flight_point import FlightPoint, _FieldDescriptor
 from fastoad.openmdao.variables import Variable, VariableList
@@ -73,8 +71,8 @@ def test_flight_point_expansion_only_once():
     assert "gearbox_shaft_power" in str(record[0].message)
 
 
-def test_compute_perfo_single_flight_point():
-    """Test compute_performances() with a single FlightPoint."""
+def test_compute_single_point_backward():
+    """Test compute_single_point_backward() with a single FlightPoint."""
     component = PropellerComponent()
 
     fp = FlightPoint()
@@ -82,36 +80,27 @@ def test_compute_perfo_single_flight_point():
     fp.true_airspeed = 200.0  # m/s
     component.input_parameters["data:propulsion:propeller:efficiency"].value = 0.85
 
-    component.compute_performances(fp)
+    component.compute_single_point_backward(fp)
 
     # Expected: (50000 * 200) / 0.85 = 11764705.88...
     expected_power = (50000.0 * 200.0) / 0.85
     assert fp.gearbox_shaft_power == pytest.approx(expected_power, rel=1e-6)
 
 
-def test_compute_perfo_list_of_flight_points():
-    """Test compute_performances() with a list of FlightPoints."""
+def test_compute_single_point_forward():
+    """Test compute_single_point_forward() with a single FlightPoint."""
     component = PropellerComponent()
 
+    fp = FlightPoint()
+    fp.gearbox_shaft_power = 11764705.88  # W
+    fp.true_airspeed = 200.0  # m/s
     component.input_parameters["data:propulsion:propeller:efficiency"].value = 0.85
 
-    fp1 = FlightPoint()
-    fp1.thrust = 50000.0
-    fp1.true_airspeed = 200.0
+    component.compute_single_point_forward(fp)
 
-    fp2 = FlightPoint()
-    fp2.thrust = 60000.0
-    fp2.true_airspeed = 250.0
-
-    flightpoints = pd.DataFrame([fp1, fp2])
-    component.compute_performances(flightpoints)
-
-    # First result: (50000 * 200) / 0.85
-    expected_power1 = (50000.0 * 200.0) / 0.85
-    # Second result: (60000 * 250) / 0.85
-    expected_power2 = (60000.0 * 250.0) / 0.85
-    expected = [expected_power1, expected_power2]
-    assert np.allclose(flightpoints.gearbox_shaft_power.to_list(), expected, rtol=1e-6)
+    # Expected: (50000 * 200) / 0.85 = 11764705.88 * 0.85 / 200 = 50000
+    expected_thrust = 11764705.88 * 0.85 / 200
+    assert fp.thrust == pytest.approx(expected_thrust, rel=1e-6)
 
 
 def test_inputs_can_be_updated_using_update():

--- a/src/rta/models/propulsion/tests/test_gearbox.py
+++ b/src/rta/models/propulsion/tests/test_gearbox.py
@@ -18,16 +18,14 @@ power transmission calculations.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import numpy as np
-import pandas as pd
 import pytest
 from fastoad.model_base.flight_point import FlightPoint
 
 from rta.models.propulsion.tests.dummy_components.gearbox import GearboxComponent
 
 
-def test_gearbox_compute_perfo_single_flight_point():
-    """Test compute_performances() with a single FlightPoint."""
+def test_gearbox_compute_single_point_backward():
+    """Test single_point_backward() with a single FlightPoint."""
     # Add the input field for gearbox
     FlightPoint.add_field(name="gearbox_shaft_power", unit="W")
     gearbox = GearboxComponent()
@@ -36,32 +34,25 @@ def test_gearbox_compute_perfo_single_flight_point():
     fp = FlightPoint()
     fp.gearbox_shaft_power = 500000.0  # W
 
-    gearbox.compute_performances(fp)
+    gearbox.compute_single_point_backward(fp)
 
-    # The expected results is: 500000 / 0.90 = 550000
+    # The expected results is: 500000 / 0.90 = 555555.5
     expected_power = 500000.0 / 0.90
     assert fp.TPshaft_power == pytest.approx(expected_power, rel=1e-6)
 
 
-def test_gearbox_compute_perfo_list_of_flight_points():
-    """Test compute_performances() with a list of FlightPoints."""
-    # Add the input field for gearbox
+def test_gearbox_compute_single_point_forward():
+    """Test single_point_forward() with a single FlightPoint."""
+
     FlightPoint.add_field(name="gearbox_shaft_power", unit="W")
     gearbox = GearboxComponent()
-    gearbox.input_parameters["data:propulsion:gearbox:efficiency"].value = 0.95
+    gearbox.input_parameters["data:propulsion:gearbox:efficiency"].value = 0.90
 
-    fp1 = FlightPoint()
-    fp1.gearbox_shaft_power = 1000000.0
+    fp = FlightPoint()
+    fp.TPshaft_power = 555555.5  # W
 
-    fp2 = FlightPoint()
-    fp2.gearbox_shaft_power = 2000000.0
+    gearbox.compute_single_point_forward(fp)
 
-    flight_points = pd.DataFrame([fp1, fp2])
-    gearbox.compute_performances(flight_points)
-
-    # First result: 1000000 / 0.95
-    expected_power1 = 1000000.0 / 0.95
-    # Second result: 2000000 / 0.95
-    expected_power2 = 2000000.0 / 0.95
-    expected = [expected_power1, expected_power2]
-    assert np.allclose(flight_points.TPshaft_power.to_list(), expected, rtol=1e-6)
+    # The expected results is: 550000 * 0.90 = 500000
+    expected_power = 555555.5 * 0.90
+    assert fp.gearbox_shaft_power == pytest.approx(expected_power, rel=1e-6)

--- a/src/rta/models/propulsion/tests/test_gearbox.py
+++ b/src/rta/models/propulsion/tests/test_gearbox.py
@@ -53,6 +53,6 @@ def test_gearbox_compute_single_point_forward():
 
     gearbox.compute_single_point_forward(fp)
 
-    # The expected results is: 550000 * 0.90 = 500000
+    # The expected results is: 555555.5 * 0.90 = 500000
     expected_power = 555555.5 * 0.90
     assert fp.gearbox_shaft_power == pytest.approx(expected_power, rel=1e-6)

--- a/src/rta/models/propulsion/tests/test_omwrapper.py
+++ b/src/rta/models/propulsion/tests/test_omwrapper.py
@@ -27,6 +27,7 @@ def test_PropulsionSystemOMComponent():
 
     true_airspeed = [15, 30, 60, 90, 120]
     thrusts = [10e3, 7.5e3, 5e3, 2.5e3, 1.0e3]
+    thrust_is_regulated = [1, 1, 1, 1, 1]
 
     propeller_efficiency = 0.85
     gearbox_efficiency = 0.95
@@ -40,6 +41,7 @@ def test_PropulsionSystemOMComponent():
 
     ivc.add_output("data:propulsion:true_airspeed", true_airspeed, units="m/s")
     ivc.add_output("data:propulsion:thrust", thrusts, units="N")
+    ivc.add_output("data:propulsion:thrust_is_regulated", thrust_is_regulated, units="unitless")
 
     problem = run_system(engine, ivc)
 

--- a/src/rta/models/propulsion/tests/test_propulsion_system_module.py
+++ b/src/rta/models/propulsion/tests/test_propulsion_system_module.py
@@ -69,6 +69,7 @@ def test_propulsion_system_module_compute_single_flight_point():
     fp = FlightPoint()
     fp.thrust = 50000.0  # N
     fp.true_airspeed = 200.0  # m/s
+    fp.thrust_is_regulated = 1
 
     module.compute_flight_points(fp)
 
@@ -87,14 +88,18 @@ def test_propulsion_system_module_compute_single_flight_point():
     # Step 4: SFC = fuel_flow / thrust
     expected_sfc = expected_fuel_flow / 50000.0
 
+    # Step 5: Throttle ratio
+    expected_thrust_rate = expected_tpshaft_power / 20e6
+
     assert fp.gearbox_shaft_power == pytest.approx(expected_gearbox_shaft_power, rel=1e-6)
     assert fp.TPshaft_power == pytest.approx(expected_tpshaft_power, rel=1e-6)
     assert fp.psfc == pytest.approx(psfc_kg_per_w_s, rel=1e-6)
     assert fp.sfc == pytest.approx(expected_sfc, rel=1e-6)
+    assert fp.thrust_rate == pytest.approx(expected_thrust_rate, rel=1e-6)
 
 
 def test_propulsion_system_module_compute_list_of_flight_points():
-    """Test compute_flight_points() with a list of FlightPoints."""
+    """Test compute_flight_points() with a list of FlightPoints in backward mode."""
     propeller = PropellerComponent()
     gearbox = GearboxComponent()
 
@@ -111,10 +116,12 @@ def test_propulsion_system_module_compute_list_of_flight_points():
     fp1 = FlightPoint()
     fp1.thrust = 50000.0  # N
     fp1.true_airspeed = 200.0  # m/s
+    fp1.thrust_is_regulated = 1  # unitless
 
     fp2 = FlightPoint()
     fp2.thrust = 60000.0  # N
     fp2.true_airspeed = 250.0  # m/s
+    fp2.thrust_is_regulated = 1  # unitless
 
     flight_points = pd.DataFrame([fp1, fp2])
     module.compute_flight_points(flight_points)
@@ -128,6 +135,8 @@ def test_propulsion_system_module_compute_list_of_flight_points():
     expected_fuel_flow1 = psfc_kg_per_w_s * expected_tpshaft_power1
     # SFC
     expected_sfc1 = expected_fuel_flow1 / 50000.0
+    # Throttle ratio
+    expected_thrust_rate1 = expected_tpshaft_power1 / 20e6
 
     # Second flight point
     expected_gearbox_shaft_power2 = (60000.0 * 250.0) / 0.85
@@ -137,13 +146,122 @@ def test_propulsion_system_module_compute_list_of_flight_points():
     expected_fuel_flow2 = psfc_kg_per_w_s * expected_tpshaft_power2
     # SFC
     expected_sfc2 = expected_fuel_flow2 / 60000.0
+    # Throttle ratio
+    expected_thrust_rate2 = expected_tpshaft_power2 / 20e6
 
     expected_gearbox_shaft_power = [expected_gearbox_shaft_power1, expected_gearbox_shaft_power2]
     expected_tpshaft_power = [expected_tpshaft_power1, expected_tpshaft_power2]
     expected_sfc = [expected_sfc1, expected_sfc2]
+    expected_thrust_rate = [expected_thrust_rate1, expected_thrust_rate2]
 
     assert np.allclose(
         expected_gearbox_shaft_power, flight_points.gearbox_shaft_power.to_list(), rtol=1e-6
     )
     assert np.allclose(expected_tpshaft_power, flight_points.TPshaft_power.to_list(), rtol=1e-6)
     assert np.allclose(expected_sfc, flight_points.sfc.to_list(), rtol=1e-6)
+    assert np.allclose(expected_thrust_rate, flight_points.thrust_rate.to_list(), rtol=1e-6)
+
+
+def test_propulsion_system_module_compute_list_of_flight_points_forward():
+    """Test compute_flight_points() with a list of FlightPoints in forward mode."""
+    propeller = PropellerComponent()
+    gearbox = GearboxComponent()
+
+    # Set propeller efficiency to 0.85
+    propeller.input_parameters["data:propulsion:propeller:efficiency"].value = 0.85
+    # Set gearbox efficiency to 0.90
+    gearbox.input_parameters["data:propulsion:gearbox:efficiency"].value = 0.90
+
+    module = PropulsionSystemModule(
+        propeller=propeller,
+        gearbox=gearbox,
+    )
+
+    fp1 = FlightPoint()
+    fp1.thrust_rate = 0.5  # N
+    fp1.true_airspeed = 200.0  # m/s
+    fp1.thrust_is_regulated = 0  # unitless
+
+    fp2 = FlightPoint()
+    fp2.thrust_rate = 0.93  # N
+    fp2.true_airspeed = 250.0  # m/s
+    fp2.thrust_is_regulated = 0  # unitless
+
+    flight_points = pd.DataFrame([fp1, fp2])
+    module.compute_flight_points(flight_points)
+
+    # First flight point
+    expected_tpshaft_power1 = 20e6 * 0.5
+    expected_gearbox_shaft_power1 = expected_tpshaft_power1 * 0.90
+    expected_thrust1 = expected_gearbox_shaft_power1 * 0.85 / 200
+
+    # Fuel flow
+    psfc_kg_per_w_s = 0.250 / (1000.0 * 3600.0)
+    expected_fuel_flow1 = psfc_kg_per_w_s * expected_tpshaft_power1
+    # SFC
+    expected_sfc1 = expected_fuel_flow1 / expected_thrust1
+
+    # Second flight point
+    expected_tpshaft_power2 = 20e6 * 0.93
+    expected_gearbox_shaft_power2 = expected_tpshaft_power2 * 0.90
+    expected_thrust2 = expected_gearbox_shaft_power2 * 0.85 / 250.0
+
+    # Fuel flow
+    expected_fuel_flow2 = psfc_kg_per_w_s * expected_tpshaft_power2
+    # SFC
+    expected_sfc2 = expected_fuel_flow2 / expected_thrust2
+
+    expected_gearbox_shaft_power = [expected_gearbox_shaft_power1, expected_gearbox_shaft_power2]
+    expected_tpshaft_power = [expected_tpshaft_power1, expected_tpshaft_power2]
+    expected_sfc = [expected_sfc1, expected_sfc2]
+    expected_thrust = [expected_thrust1, expected_thrust2]
+
+    assert np.allclose(
+        expected_gearbox_shaft_power, flight_points.gearbox_shaft_power.to_list(), rtol=1e-6
+    )
+    assert np.allclose(expected_tpshaft_power, flight_points.TPshaft_power.to_list(), rtol=1e-6)
+    assert np.allclose(expected_sfc, flight_points.sfc.to_list(), rtol=1e-6)
+    assert np.allclose(expected_thrust, flight_points.thrust.to_list(), rtol=1e-6)
+
+
+def test_propulsion_system_module_compute_list_of_flight_points_mix():
+    """Test compute_flight_points() with a list of FlightPoints in backward mode."""
+    propeller = PropellerComponent()
+    gearbox = GearboxComponent()
+
+    # Set propeller efficiency to 0.85
+    propeller.input_parameters["data:propulsion:propeller:efficiency"].value = 0.85
+    # Set gearbox efficiency to 0.90
+    gearbox.input_parameters["data:propulsion:gearbox:efficiency"].value = 0.90
+
+    module = PropulsionSystemModule(
+        propeller=propeller,
+        gearbox=gearbox,
+    )
+
+    fp1 = FlightPoint()
+    fp1.thrust = 50000.0  # N
+    fp1.true_airspeed = 200.0  # m/s
+    fp1.thrust_is_regulated = 1  # unitless
+
+    fp2 = FlightPoint()
+    fp2.thrust_rate = 0.93  # N
+    fp2.true_airspeed = 250.0  # m/s
+    fp2.thrust_is_regulated = 0  # unitless
+
+    flight_points = pd.DataFrame([fp1, fp2])
+    module.compute_flight_points(flight_points)
+
+    expected_gearbox_shaft_power = [11764705.8, 16740000.0]
+    expected_tpshaft_power = [13071895.4, 18600000.0]
+    expected_sfc = [1.815541e-5, 2.269426e-5]
+    expected_thrust = [50000.0, 56916.0]
+    expected_thrust_rate = [0.6535948, 0.93]
+
+    assert np.allclose(
+        expected_gearbox_shaft_power, flight_points.gearbox_shaft_power.to_list(), rtol=1e-6
+    )
+    assert np.allclose(expected_tpshaft_power, flight_points.TPshaft_power.to_list(), rtol=1e-6)
+    assert np.allclose(expected_sfc, flight_points.sfc.to_list(), rtol=1e-6)
+    assert np.allclose(expected_thrust, flight_points.thrust.to_list(), rtol=1e-6)
+    assert np.allclose(expected_thrust_rate, flight_points.thrust_rate.to_list(), rtol=1e-6)

--- a/src/rta/models/propulsion/tests/test_propulsion_system_module.py
+++ b/src/rta/models/propulsion/tests/test_propulsion_system_module.py
@@ -178,12 +178,12 @@ def test_propulsion_system_module_compute_list_of_flight_points_forward():
     )
 
     fp1 = FlightPoint()
-    fp1.thrust_rate = 0.5  # N
+    fp1.thrust_rate = 0.5  # unitless
     fp1.true_airspeed = 200.0  # m/s
     fp1.thrust_is_regulated = 0  # unitless
 
     fp2 = FlightPoint()
-    fp2.thrust_rate = 0.93  # N
+    fp2.thrust_rate = 0.93  # unitless
     fp2.true_airspeed = 250.0  # m/s
     fp2.thrust_is_regulated = 0  # unitless
 
@@ -225,7 +225,7 @@ def test_propulsion_system_module_compute_list_of_flight_points_forward():
 
 
 def test_propulsion_system_module_compute_list_of_flight_points_mix():
-    """Test compute_flight_points() with a list of FlightPoints in backward mode."""
+    """Test compute_flight_points() with a list of FlightPoints in mixed backward/forward modes."""
     propeller = PropellerComponent()
     gearbox = GearboxComponent()
 
@@ -245,7 +245,7 @@ def test_propulsion_system_module_compute_list_of_flight_points_mix():
     fp1.thrust_is_regulated = 1  # unitless
 
     fp2 = FlightPoint()
-    fp2.thrust_rate = 0.93  # N
+    fp2.thrust_rate = 0.93  # unitless
     fp2.true_airspeed = 250.0  # m/s
     fp2.thrust_is_regulated = 0  # unitless
 


### PR DESCRIPTION
As a follow-up to #17, this PR adds a way to compute both in backward and forward mode. Users are now tasked with implementing two functions. Additionally, the system has to orchestrate two types of components depending on whether we are in forward or backward mode.

Some trial and errors revealed that the proposed implementation of the propulsion is not suited to handle cases where flight_point is neither a float nor a pandas dataframe. For instance, if one field is a float and others are arrays.

In the rubber engine implementation, it is not an issue as the explicit model we use can handle both arrays and floats, but can we expect that for every component we will implement ?

This PR closes #17 